### PR TITLE
Getting arguments by file and some refactoring

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+**/ckpts
+**/__pycache__

--- a/README.md
+++ b/README.md
@@ -29,7 +29,8 @@ Due to large sizes of images in QNRF and NWPU datasets, we preprocess these two 
 python preprocess_dataset.py --dataset <dataset name: qnrf or nwpu> --input-dataset-path <original data directory> --output-dataset-path <processed data directory> 
 ```
     
-3. Training
+3. Training  
+[Here](https://www.kaggle.com/selmanzleyen/dmcount-shb) is a kaggle notebook for a quickstart.
 The interface is like this;
 ```
 usage: train.py [-h] [--load-args LOAD_ARGS] [--data-path DATA_PATH] [--dataset {qnrf,nwpu,sha,shb}]

--- a/README.md
+++ b/README.md
@@ -30,15 +30,117 @@ python preprocess_dataset.py --dataset <dataset name: qnrf or nwpu> --input-data
 ```
     
 3. Training
+The interface is like this;
+```
+usage: train.py [-h] [--load-args LOAD_ARGS] [--data-path DATA_PATH] [--dataset {qnrf,nwpu,sha,shb}]
+                [--out-path OUT_PATH] [--lr LR] [--weight-decay WEIGHT_DECAY] [--resume RESUME]
+                [--auto-resume] [--max-epoch MAX_EPOCH] [--val-epoch VAL_EPOCH] [--val-start VAL_START]
+                [--batch-size BATCH_SIZE] [--device DEVICE] [--num-workers NUM_WORKERS] [--wot WOT]
+                [--wtv WTV] [--reg REG] [--num-of-iter-in-ot NUM_OF_ITER_IN_OT] [--norm-cood NORM_COOD]
 
+Train
+
+optional arguments:
+  -h, --help            show this help message and exit
+  --load-args LOAD_ARGS
+                        file to read program args from. Will ignore other parameters if specified
+  --data-path DATA_PATH
+                        dataset path
+  --dataset {qnrf,nwpu,sha,shb}
+                        dataset name
+  --out-path OUT_PATH   place to save checkpoints and models.
+  --lr LR               initial learning rate
+  --weight-decay WEIGHT_DECAY
+                        the weight decay
+  --resume RESUME       state dict to resume from. If specified as empty will start over
+  --auto-resume         if set will try to find most recent checkpoint in 'out_path'
+  --max-epoch MAX_EPOCH
+                        max training epoch
+  --val-epoch VAL_EPOCH
+                        the num of steps to log training information
+  --val-start VAL_START
+                        the epoch start to val
+  --batch-size BATCH_SIZE
+                        train batch size
+  --device DEVICE       assign device
+  --num-workers NUM_WORKERS
+                        the num of training process
+  --wot WOT             weight on OT loss
+  --wtv WTV             weight on TV loss
+  --reg REG             entropy regularization in sinkhorn
+  --num-of-iter-in-ot NUM_OF_ITER_IN_OT
+                        sinkhorn iterations
+  --norm-cood NORM_COOD
+                        Whether to norm cood when computing distance
 ```
-python train.py --dataset <dataset name: qnrf, sha, shb or nwpu> --data-dir <path to dataset> --device <gpu device id>
+Training can be done two ways;
 ```
+python train.py --dataset <dataset name: qnrf, sha, shb or nwpu> --data-path <path to dataset> --device <gpu device id>
+```  
+ or from a desired .json file like args.json in the repository for example;
+```
+python train.py --load-args args.json
+```
+When this option is specified other given option from the terminal will be ignored. Some default configurations specific to the selected dataset can be changed from datasets/dataset_cfg.json file.  
+To directly run it with default arguments 
+make sure you select these correctly;
+from args.json file;
+```
+..
+"train":{
+  ...
+  "dataset":<dataset name>
+  ...
+  }
+..
+```
+and from datasets/dataset_cfg.json;
+```
+{
+  ..
+    ...
+    "dataset_paths":{
+        "<dataset name>":{
+            "data_path":"<dataset root path>", <-- this is important
+            other attributes are generally the default
+        },
+      ...
+    }
+  ..
+}
+```
+
 
 4. Test
 
+The interface is like this;
+```
+usage: test.py [-h] [--load-args LOAD_ARGS] [--device DEVICE] [--model-path MODEL_PATH]
+               [--data-path DATA_PATH] [--dataset {qnrf,nwpu,sha,shb}]
+               [--pred-density-map-path PRED_DENSITY_MAP_PATH]
+
+Test
+
+optional arguments:
+  -h, --help            show this help message and exit
+  --load-args LOAD_ARGS
+                        file to read program args from. Will ignore other parameters if specified
+  --device DEVICE       assign device
+  --model-path MODEL_PATH
+                        saved model path
+  --data-path DATA_PATH
+                        dataset path
+  --dataset {qnrf,nwpu,sha,shb}
+                        dataset name
+  --pred-density-map-path PRED_DENSITY_MAP_PATH
+                        save predicted density maps when pred-density-map-path is not empty.
+```
 ```
 python test.py --model-path <path of the model to be evaluated> --data-path <directory for the dataset> --dataset <dataset name: qnrf, sha, shb or nwpu>
+```
+The same applies here you can also use args.json file to load like this;
+```
+python test.py --load-args args.json
 ```
 
 ## Pretrained models

--- a/args.json
+++ b/args.json
@@ -1,0 +1,30 @@
+{
+    "train":{
+        "load_args":"True",
+        "out_path":"./",
+        "dataset":"sha",
+        "lr":1e-5,
+        "weight_decay":1e-4,
+        "resume":"",
+        "auto_resume":"True",
+        "max_epoch":1000,
+        "val_epoch":5,
+        "val_start":50,
+        "batch_size":10,
+        "device":"0",
+        "num_workers":3,
+        "wot":0.1,
+        "wtv":0.01,
+        "reg":10.0,
+        "num_of_iter_in_ot":100,
+        "norm_cood":0
+    },
+    "test":{
+        "load_args":"True",
+        "device":"0",
+        "model_path":"/DM-Count/pretrained_models/model_nwpu.pth",
+        "data_path":"/ShanghaiTech/part_A",
+        "dataset":"sha",
+        "pred_density_map_path":""
+    }
+}

--- a/datasets/dataset_cfg.json
+++ b/datasets/dataset_cfg.json
@@ -1,0 +1,45 @@
+
+{
+    "datasets":["qnrf","nwpu","sha","shb"],
+    "default_dataset_params":{
+        "qnrf":{
+            "crop_size":512,
+            "val_epoch":5
+        },
+        "nwpu":{
+            "crop_size":384,
+            "val_epoch":50
+        },
+        "sha":{
+            "crop_size":256,
+            "val_epoch":5
+        },
+        "shb":{
+            "crop_size":512,
+            "val_epoch":5      
+        }
+    },
+    "dataset_paths":{
+        "qnrf":{
+            "data_path":"data/UCF-Train-Val-Test",
+            "val_path":"val",
+            "train_path":"train"
+        },
+        "nwpu":{
+            "data_path":"data/UCF-Train-Val-Test",
+            "val_path":"val",
+            "train_path":"train"
+        },
+        "sha":{
+            "data_path":"/ShanghaiTech/part_A",
+            "val_path":"test_data",
+            "train_path":"train_data"
+        },
+        "shb":{
+            "data_path":"~/ShanghaiTech/part_B",
+            "val_path":"test_data",
+            "train_path":"train_data"
+        }
+    }
+}
+

--- a/losses/bregman_pytorch.py
+++ b/losses/bregman_pytorch.py
@@ -143,8 +143,8 @@ def sinkhorn_knopp(a, b, C, reg=1e-1, maxIter=1000, stopThr=1e-9,
     assert na >= 1 and nb >= 1, 'C needs to be 2d'
     assert na == a.shape[0] and nb == b.shape[0], "Shape of a or b does't match that of C"
     assert reg > 0, 'reg should be greater than 0'
-    assert a.min() >= 0. and b.min() >= 0., 'Elements in a or b less than 0'
-
+    # assert a.min() >= 0. and b.min() >= 0., 'Elements in a or b less than 0'
+    # unnecessary check for our special case
     if log:
         log = {'err': []}
 

--- a/losses/ot_loss.py
+++ b/losses/ot_loss.py
@@ -16,6 +16,7 @@ class OT_Loss(Module):
         # coordinate is same to image space, set to constant since crop size is same
         self.cood = torch.arange(0, c_size, step=stride,
                                  dtype=torch.float32, device=device) + stride / 2
+        self.cood_sqaured = self.cood*self.cood # storing the precalculated matrix
         self.density_size = self.cood.size(0)
         self.cood.unsqueeze_(0) # [1, #cood]
         if self.norm_cood:
@@ -38,8 +39,8 @@ class OT_Loss(Module):
                     im_points = im_points / self.c_size * 2 - 1 # map to [-1, 1]
                 x = im_points[:, 0].unsqueeze_(1)  # [N, 1]
                 y = im_points[:, 1].unsqueeze_(1)
-                x_dis = -2 * torch.matmul(x, self.cood) + x * x + self.cood * self.cood # [#gt, #cood]
-                y_dis = -2 * torch.matmul(y, self.cood) + y * y + self.cood * self.cood
+                x_dis = -2 * torch.matmul(x, self.cood) + x * x + self.cood_sqaured # [#gt, #cood]
+                y_dis = -2 * torch.matmul(y, self.cood) + y * y + self.cood_sqaured
                 y_dis.unsqueeze_(2)
                 x_dis.unsqueeze_(1)
                 dis = y_dis + x_dis

--- a/test.py
+++ b/test.py
@@ -4,70 +4,95 @@ import os
 import numpy as np
 import datasets.crowd as crowd
 from models import vgg19
-
-parser = argparse.ArgumentParser(description='Test ')
-parser.add_argument('--device', default='0', help='assign device')
-parser.add_argument('--crop-size', type=int, default=512,
-                    help='the crop size of the train image')
-parser.add_argument('--model-path', type=str, default='pretrained_models/model_qnrf.pth',
-                    help='saved model path')
-parser.add_argument('--data-path', type=str,
-                    default='data/QNRF-Train-Val-Test',
-                    help='saved model path')
-parser.add_argument('--dataset', type=str, default='qnrf',
-                    help='dataset name: qnrf, nwpu, sha, shb')
-parser.add_argument('--pred-density-map-path', type=str, default='',
-                    help='save predicted density maps when pred-density-map-path is not empty.')
+import utils.arg_utils
+from utils.config import DATASET_LIST,DATASET_PARAMS,DATASET_PATHS,ARGS,DOWNSAMPLE_RATIO
 
 
-args = parser.parse_args()
+def parse_args():
+    parser = argparse.ArgumentParser(description='Test ')
+    parser.add_argument('--load-args',
+                        help='file to read program args from.'+
+                        ' Will ignore other parameters if specified',required=False)
+    parser.add_argument('--device', default='0', help='assign device')
+    parser.add_argument('--model-path', type=str, default='pretrained_models/model_qnrf.pth',
+                        help='saved model path')
+    parser.add_argument('--data-path', type=str,
+                        default='data/QNRF-Train-Val-Test',help='dataset path')
+    parser.add_argument('--dataset', help='dataset name', choices=DATASET_LIST,
+                           default='qnrf')
+    parser.add_argument('--pred-density-map-path', type=str, default='',
+                        help='save predicted density maps when pred-density-map-path is not empty.')
+    args = parser.parse_args()
+    # load default dataset configurations from datasets/dataset_cfg.json
+    def_args_dict = {**DATASET_PARAMS[ARGS['test']['dataset']],
+                    **DATASET_PATHS[ARGS['test']['dataset']]}
+    # if json file is specified ignore all given options
+    if args.load_args:
+        def_args_dict.update(**ARGS['test'])
+    else: 
+        def_args_dict.update(**vars(args))
+    # overriding default arguments
+    args = argparse.Namespace(**def_args_dict)
 
-os.environ['CUDA_VISIBLE_DEVICES'] = args.device  # set vis gpu
-device = torch.device('cuda')
+    return args
 
-model_path = args.model_path
-crop_size = args.crop_size
-data_path = args.data_path
-if args.dataset.lower() == 'qnrf':
-    dataset = crowd.Crowd_qnrf(os.path.join(data_path, 'test'), crop_size, 8, method='val')
-elif args.dataset.lower() == 'nwpu':
-    dataset = crowd.Crowd_nwpu(os.path.join(data_path, 'val'), crop_size, 8, method='val')
-elif args.dataset.lower() == 'sha' or args.dataset.lower() == 'shb':
-    dataset = crowd.Crowd_sh(os.path.join(data_path, 'test_data'), crop_size, 8, method='val')
-else:
-    raise NotImplementedError
-dataloader = torch.utils.data.DataLoader(dataset, 1, shuffle=False,
-                                         num_workers=1, pin_memory=True)
 
-if args.pred_density_map_path:
-    import cv2
-    if not os.path.exists(args.pred_density_map_path):
-        os.makedirs(args.pred_density_map_path)
+if __name__ == '__main__':
+    args = parse_args()
+    os.environ['CUDA_VISIBLE_DEVICES'] = args.device.strip()  # set vis gpu
+    device = torch.device('cuda')
 
-model = vgg19()
-model.to(device)
-model.load_state_dict(torch.load(model_path, device))
-model.eval()
-image_errs = []
-for inputs, count, name in dataloader:
-    inputs = inputs.to(device)
-    assert inputs.size(0) == 1, 'the batch size should equal to 1'
-    with torch.set_grad_enabled(False):
-        outputs, _ = model(inputs)
-    img_err = count[0].item() - torch.sum(outputs).item()
+    model_path = args.model_path
+    crop_size = args.crop_size
+    data_path = args.data_path
 
-    print(name, img_err, count[0].item(), torch.sum(outputs).item())
-    image_errs.append(img_err)
+    dataset_name = args.dataset.lower()
+    if dataset_name == 'qnrf':
+        from datasets.crowd import Crowd_qnrf as Crowd
+    elif dataset_name == 'nwpu':
+        from datasets.crowd import Crowd_nwpu as Crowd
+    elif dataset_name == 'sha':
+        from datasets.crowd import Crowd_sh as Crowd
+    elif dataset_name == 'shb':
+        from datasets.crowd import Crowd_sh as Crowd
+    else:
+        raise NotImplementedError
+
+    dataset = Crowd(os.path.join(args.data_path, DATASET_PATHS[dataset_name]["val_path"]),
+                        crop_size=args.crop_size,
+                        downsample_ratio=DOWNSAMPLE_RATIO, method='val')
+    dataloader = torch.utils.data.DataLoader(dataset, 1, shuffle=False,
+                                            num_workers=1, pin_memory=True)
 
     if args.pred_density_map_path:
-        vis_img = outputs[0, 0].cpu().numpy()
-        # normalize density map values from 0 to 1, then map it to 0-255.
-        vis_img = (vis_img - vis_img.min()) / (vis_img.max() - vis_img.min() + 1e-5)
-        vis_img = (vis_img * 255).astype(np.uint8)
-        vis_img = cv2.applyColorMap(vis_img, cv2.COLORMAP_JET)
-        cv2.imwrite(os.path.join(args.pred_density_map_path, str(name[0]) + '.png'), vis_img)
+        import cv2
+        if not os.path.exists(args.pred_density_map_path):
+            os.makedirs(args.pred_density_map_path)
 
-image_errs = np.array(image_errs)
-mse = np.sqrt(np.mean(np.square(image_errs)))
-mae = np.mean(np.abs(image_errs))
-print('{}: mae {}, mse {}\n'.format(model_path, mae, mse))
+    model = vgg19()
+    model.to(device)
+    model.load_state_dict(torch.load(model_path, device))
+    model.eval()
+    image_errs = []
+    for inputs, count, name in dataloader:
+        inputs = inputs.to(device)
+        assert inputs.size(0) == 1, 'the batch size should equal to 1'
+        with torch.set_grad_enabled(False):
+            outputs, _ = model(inputs)
+        img_err = count[0].item() - torch.sum(outputs).item()
+
+        print(name, img_err, count[0].item(), torch.sum(outputs).item())
+        image_errs.append(img_err)
+
+        if args.pred_density_map_path:
+            vis_img = outputs[0, 0].cpu().numpy()
+            # normalize density map values from 0 to 1, then map it to 0-255.
+            vis_img = (vis_img - vis_img.min()) / (vis_img.max() - vis_img.min() + 1e-5)
+            vis_img = (vis_img * 255).astype(np.uint8)
+            vis_img = cv2.applyColorMap(vis_img, cv2.COLORMAP_JET)
+            cv2.imwrite(os.path.join(args.pred_density_map_path, str(name[0]) + '.png'), vis_img)
+
+    image_errs = np.array(image_errs)
+    mse = np.sqrt(np.mean(np.square(image_errs)))
+    mae = np.mean(np.abs(image_errs))
+    print('{}: mae {}, mse {}\n'.format(model_path, mae, mse))

--- a/test.py
+++ b/test.py
@@ -22,14 +22,17 @@ def parse_args():
                            default='qnrf')
     parser.add_argument('--pred-density-map-path', type=str, default='',
                         help='save predicted density maps when pred-density-map-path is not empty.')
-    args = parser.parse_args()
-    # load default dataset configurations from datasets/dataset_cfg.json
-    def_args_dict = {**DATASET_PARAMS[ARGS['test']['dataset']],
-                    **DATASET_PATHS[ARGS['test']['dataset']]}
     # if json file is specified ignore all given options
     if args.load_args:
-        def_args_dict.update(**ARGS['test'])
-    else: 
+        args = utils.config.load_args(args.load_args)
+        # load default dataset configurations from datasets/dataset_cfg.json
+        def_args_dict = {**DATASET_PARAMS[args['test']['dataset']],
+                        **DATASET_PATHS[args['test']['dataset']]}
+        def_args_dict.update(**args['test'])
+    else:
+        # load default dataset configurations from datasets/dataset_cfg.json
+        def_args_dict = {**DATASET_PARAMS[args.dataset],
+                        **DATASET_PATHS[args.dataset]}
         def_args_dict.update(**vars(args))
     # overriding default arguments
     args = argparse.Namespace(**def_args_dict)

--- a/train.py
+++ b/train.py
@@ -2,56 +2,63 @@ import argparse
 import os
 import torch
 from train_helper import Trainer
-
-
-def str2bool(v):
-    return v.lower() in ("yes", "true", "t", "1")
-
+from utils.config import DATASET_LIST,DATASET_PARAMS,ARGS,DATASET_PATHS,DOWNSAMPLE_RATIO
+import utils.arg_utils
 
 def parse_args():
     parser = argparse.ArgumentParser(description='Train')
-    parser.add_argument('--data-dir', default='data/UCF-Train-Val-Test', help='data path')
-    parser.add_argument('--dataset', default='qnrf', help='dataset name: qnrf, nwpu, sha, shb')
-    parser.add_argument('--lr', type=float, default=1e-5,
-                        help='the initial learning rate')
-    parser.add_argument('--weight-decay', type=float, default=1e-4,
-                        help='the weight decay')
-    parser.add_argument('--resume', default='', type=str,
-                        help='the path of resume training model')
+    parser.add_argument('--load-args',
+                        help='file to read program args from.'+
+                        ' Will ignore other parameters if specified',required=False)
+    parser.add_argument('--data-path', default='data/UCF-Train-Val-Test', help='dataset path')
+    parser.add_argument('--dataset', help='dataset name', choices=DATASET_LIST,
+                           default='qnrf')
+    parser.add_argument('--out-path', help='place to save checkpoints and models.', default='./')
+    parser.add_argument('--lr', type=float, default='1e-5',
+                          help='initial learning rate')
+    parser.add_argument('--weight-decay', type=float, default="1e-4",
+                          help='the weight decay')
+    parser.add_argument('--resume', type=str, default='',
+                          help='state dict to resume from. If specified as empty will start over')
+    parser.add_argument('--auto-resume', action='store_true',default=False,
+                          help="if set will try to find most recent checkpoint in 'out_path' ")
     parser.add_argument('--max-epoch', type=int, default=1000,
-                        help='max training epoch')
-    parser.add_argument('--val-epoch', type=int, default=5,
-                        help='the num of steps to log training information')
+                          help='max training epoch')
+    parser.add_argument('--val-epoch', type=int, required=False,
+                          help='the num of steps to log training information')
     parser.add_argument('--val-start', type=int, default=50,
-                        help='the epoch start to val')
+                          help='the epoch start to val')
     parser.add_argument('--batch-size', type=int, default=10,
-                        help='train batch size')
+                          help='train batch size')
     parser.add_argument('--device', default='0', help='assign device')
     parser.add_argument('--num-workers', type=int, default=3,
-                        help='the num of training process')
-    parser.add_argument('--crop-size', type=int, default=512,
-                        help='the crop size of the train image')
+                          help='the num of training process')
     parser.add_argument('--wot', type=float, default=0.1, help='weight on OT loss')
     parser.add_argument('--wtv', type=float, default=0.01, help='weight on TV loss')
     parser.add_argument('--reg', type=float, default=10.0,
-                        help='entropy regularization in sinkhorn')
+                          help='entropy regularization in sinkhorn')
     parser.add_argument('--num-of-iter-in-ot', type=int, default=100,
-                        help='sinkhorn iterations')
-    parser.add_argument('--norm-cood', type=int, default=0, help='whether to norm cood when computing distance')
-
+                         help='sinkhorn iterations')
+    parser.add_argument('--norm-cood', type=int, default=0, help='Whether to norm cood when computing distance')
+    
+    
     args = parser.parse_args()
 
-    if args.dataset.lower() == 'qnrf':
-        args.crop_size = 512
-    elif args.dataset.lower() == 'nwpu':
-        args.crop_size = 384
-        args.val_epoch = 50
-    elif args.dataset.lower() == 'sha':
-        args.crop_size = 256
-    elif args.dataset.lower() == 'shb':
-        args.crop_size = 512
-    else:
-        raise NotImplementedError
+    # load default dataset configurations from datasets/dataset_cfg.json
+    def_args_dict = {**DATASET_PARAMS[ARGS['train']['dataset']],
+                    **DATASET_PATHS[ARGS['train']['dataset']]}
+    # if json file is specified ignore all given options
+    if args.load_args:
+        def_args_dict.update(**ARGS['train'])
+    else: 
+        def_args_dict.update(**vars(args))
+    # overriding default arguments
+    args = argparse.Namespace(**def_args_dict)
+
+    # if auto-resume is specified and not resume is not specified explicitly 
+    if not args.resume and 'auto_resume' in args:
+        utils.arg_utils.assign_latest_cp(args)
+
     return args
 
 

--- a/train.py
+++ b/train.py
@@ -2,7 +2,7 @@ import argparse
 import os
 import torch
 from train_helper import Trainer
-from utils.config import DATASET_LIST,DATASET_PARAMS,ARGS,DATASET_PATHS,DOWNSAMPLE_RATIO
+from utils.config import DATASET_LIST,DATASET_PARAMS,DATASET_PATHS,DOWNSAMPLE_RATIO
 import utils.arg_utils
 
 def parse_args():
@@ -44,13 +44,17 @@ def parse_args():
     
     args = parser.parse_args()
 
-    # load default dataset configurations from datasets/dataset_cfg.json
-    def_args_dict = {**DATASET_PARAMS[ARGS['train']['dataset']],
-                    **DATASET_PATHS[ARGS['train']['dataset']]}
     # if json file is specified ignore all given options
     if args.load_args:
-        def_args_dict.update(**ARGS['train'])
-    else: 
+        args = utils.config.load_args(args.load_args)
+        # load default dataset configurations from datasets/dataset_cfg.json
+        def_args_dict = {**DATASET_PARAMS[args['train']['dataset']],
+                        **DATASET_PATHS[args['train']['dataset']]}
+        def_args_dict.update(**args['train'])
+    else:
+        # load default dataset configurations from datasets/dataset_cfg.json
+        def_args_dict = {**DATASET_PARAMS[args.dataset],
+                        **DATASET_PATHS[args.dataset]}
         def_args_dict.update(**vars(args))
     # overriding default arguments
     args = argparse.Namespace(**def_args_dict)

--- a/utils/arg_utils.py
+++ b/utils/arg_utils.py
@@ -1,0 +1,47 @@
+def assign_latest_cp(args):
+    """
+    From the given arguments checks the 'out_path' parameters.
+    Looks for a checkpoint assuming the checkpoint was saved in out_path
+    and the previous run was with the same training parameters.
+    
+    Example:
+        If you run the program with these arguments;
+        "dataset = sha,
+        crop_size = 256,
+        wot = 0.1,
+        wtv = 0.01,
+        reg = 10.0,
+        num_of_iter_in_ot = 100,
+        norm_cood = 0"
+        out_path = /DM-Count
+        
+        After training some epochs when auto_resume is specified 
+        this function will look at this directort 
+        /DM-Count/ckpts/sha_input-256_wot-0.1_wtv-0.01_reg-10.0_nIter-100_normCood-0/
+        
+        Assuming checkpoints are saved in "x_ckpt.tar" format this function would assign
+        "/DM-Count/ckpts/sha_input-256_wot-0.1_wtv-0.01_reg-10.0_nIter-100_normCood-0/7_ckpt.tar"
+        path to args.resume
+    """
+    # take a look at the checkpoints at "out_path"
+    import os,argparse
+    ckpts_path = \
+    os.path.join(args.out_path,'ckpts',
+                    '{}_input-{}_wot-{}_wtv-{}_reg-{}_nIter-{}_normCood-{}'
+                    .format(args.dataset, args.crop_size, args.wot, args.wtv,
+                    args.reg, args.num_of_iter_in_ot, args.norm_cood))
+    def ckpt_no(f):
+        if len(os.path.basename(f).split('.')) >= 2 and \
+                os.path.basename(f).split('.')[1] == "tar":
+            return int(os.path.basename(f).split('_')[0])
+        else:
+            return None
+    if os.path.exists(ckpts_path):    
+        ckpt_list = [ckpt_no(f) for f in os.listdir(ckpts_path) if ckpt_no(f) != None]
+        if ckpt_list:
+            latest_no = max(ckpt_list)
+            args = vars(args)
+            args.update({'resume':
+                        os.path.join(ckpts_path,
+                        "{}_ckpt.tar".format(latest_no))})
+            args = argparse.Namespace(**args)

--- a/utils/config.py
+++ b/utils/config.py
@@ -1,0 +1,15 @@
+import json,os
+
+ARGS_PATH = "./args.json"
+DATASET_CFG_PATH = "./datasets/dataset_cfg.json"
+
+with open(ARGS_PATH) as f:
+    ARGS = json.load(f)
+
+with open(DATASET_CFG_PATH) as f:
+    _cfg = json.load(f)
+    DATASET_PARAMS = _cfg["default_dataset_params"]  
+    DATASET_PATHS = _cfg["dataset_paths"]
+    DATASET_LIST = _cfg["datasets"]
+
+DOWNSAMPLE_RATIO = 8

--- a/utils/config.py
+++ b/utils/config.py
@@ -3,9 +3,6 @@ import json,os
 ARGS_PATH = "./args.json"
 DATASET_CFG_PATH = "./datasets/dataset_cfg.json"
 
-with open(ARGS_PATH) as f:
-    ARGS = json.load(f)
-
 with open(DATASET_CFG_PATH) as f:
     _cfg = json.load(f)
     DATASET_PARAMS = _cfg["default_dataset_params"]  
@@ -13,3 +10,8 @@ with open(DATASET_CFG_PATH) as f:
     DATASET_LIST = _cfg["datasets"]
 
 DOWNSAMPLE_RATIO = 8
+
+def load_args(args_path):
+    with open(args_path) as f:
+        args = json.load(f)
+    return args


### PR DESCRIPTION
Hi I am working on a crowd counting project and I am using this repo. Congrats on the paper btw. I made some changes since I was using it I made some changes and thought it might be good to contribute. Here are the changes;

- training/testing arguments can be loaded from a json file as stated in readme file. So you switch between configuration templates more easily.
-  added some documentation about it
- removed crop-size argument from the cli since it is always overriden by dataset defaults.
- also dataset defaults are in a seperate json file
- minor refactoring to reduce the operation count for sinkhorns algorithm. Now  self.cood * self.cood is stored in a constant variable so it won't always multiply again also commented out an assertion which is not usefull in our specialized  case. 

There are also some new things I am planning to do such as;
- adding GCC dataset class (even though I am using one I might need to clean and create an issue for it first)
- using it with another backbone
- finding a way to vectorize therefore optimize the usage of sinkhorns algorithm implementation
- maybe using a different backbone and sharing the results